### PR TITLE
Add DOCKER_BUILDKIT=1 flag to docker build in README.md example

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -66,7 +66,7 @@ CMD ["/hello"]
 We can compile and run this with:
 
 ```
-$ docker build -t c-static .
+$ DOCKER_BUILDKIT=1 docker build -t c-static .
 ...
 $ docker run c-static
 Hello World!


### PR DESCRIPTION
This flag ensures that older versions of Docker can still build the example image using the heredoc syntax.