### PR TITLE
Many of the images use Wolfi -> Most of them

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,7 +20,7 @@ apko lets you bundle a collection of APKs into an OCI image using a declarative 
 Chainguard Images provide SBOM support and signatures for known provenance and more secure base
 images. They can be part of an approach to a secure software factory.
 
-Many of the images use the [Wolfi undistro](https://github.com/wolfi-dev/), and we are working on
+Most images use the [Wolfi undistro](https://github.com/wolfi-dev/), and we are working on
 porting the rest.
 
 ## Find and use Chainguard Images


### PR DESCRIPTION
Perhaps I'm doing this wrong, but there appears to be >10X as many images based on `wolfi-baselayout` than on `alpine-baselayout-data`.

Stragglers:

* busybox/configs/latest.apko.yaml
* gcc-musl/configs/latest.apko.yaml
* git/configs/latest-root.apko.yaml
* git/configs/latest.apko.yaml
* musl-dynamic/configs/latest.apko.yaml
* static/configs/latest.apko.yaml
