### PR TITLE
README Update: change cosign download flag to '--predicate-type'

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -150,7 +150,7 @@ All Chainguard Images come with a [Software Bill Of Materials
 The SBOM can be downloaded using the [`cosign`](https://docs.sigstore.dev/cosign/overview) tool e.g:
 
 ```
-$ cosign download attestation --type https://spdx.dev/Document --platform linux/amd64 cgr.dev/chainguard/nginx | jq -r .payload | base64 -d | jq
+$ cosign download attestation --predicate-type https://spdx.dev/Document --platform linux/amd64 cgr.dev/chainguard/nginx | jq -r .payload | base64 -d | jq
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "sbom-sha256:05f301c5da6b701a1024dce52ccb9c58a61f98cd9816432ace5c0f7bfef40df7",


### PR DESCRIPTION
From the GitHub chainguard-images [README](https://github.com/chainguard-images#sboms) page, the ```cosign download attestation``` command doesn’t work in the example. The flag ```--type``` should be ```--predicate-type``` 

From the latest cosign version of 2.1.1:

```
$ cosign download attestation --help
Download in-toto attestations from the supplied container image

Usage:
cosign download attestation [flags]

Examples:
  cosign download attestation <image uri> [--predicate-type]

Flags:
...

    --predicate-type='':
	download attestation with matching predicateType
...
```

```
$ cosign download attestation --type https://spdx.dev/Document --platform linux/amd64 cgr.dev/chainguard/nginx | jq -r .payload | base64 -d | jq
Error: unknown flag: --type
main.go:74: error during command execution: unknown flag: --type
```