### PR TITLE
Drop `secrets: read` until app requests it

### DIFF
--- a/.github/chainguard/mattmoor.sts.yaml
+++ b/.github/chainguard/mattmoor.sts.yaml
@@ -10,6 +10,6 @@ claim_pattern:
 permissions:
   metadata: read
   administration: read # To list deploy keys
-  secrets: read # To enumerate secret metadata (no values)
+  # secrets: read # To enumerate secret metadata (no values)
 
 repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
We need to make Octo STS ask for `secrets: read` before this is usable in a trust policy :(