### PR TITLE
octo-sts: Policy for Apps Script integrations

### DIFF
--- a/.github/chainguard/appscript.sts.yaml
+++ b/.github/chainguard/appscript.sts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Chainguard, Inc.
+# Copyright 2025 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 issuer: https://accounts.google.com

--- a/.github/chainguard/appscript.sts.yaml
+++ b/.github/chainguard/appscript.sts.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://accounts.google.com
+subject_pattern: .*
+# Allow client IDs from the `philde-appscripts` project.
+audience_pattern: 292217359313-[a-z0-9]+\.apps\.googleusercontent\.com
+claim_pattern:
+  email_verified: "true"
+  email: .*@chainguard.dev
+
+permissions:
+  contents: read
+  issues: read
+  organization_projects: read
+
+repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
Same policy/purpose as this: https://github.com/chainguard-dev/.github/blob/main/.github/chainguard/appscript.sts.yaml