### PR TITLE
update sts policy to be able to manage repos

### DIFF
--- a/.github/chainguard/sync-github.sts.yaml
+++ b/.github/chainguard/sync-github.sts.yaml
@@ -7,6 +7,8 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
 
 permissions:
+  administration: write # required to manage the repository
+  contents: write # required per terraform docs (https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository)
   members: write # to add/remove GitHub members
   metadata: read # to read metadata about the org
 

--- a/.github/chainguard/verify-github.sts.yaml
+++ b/.github/chainguard/verify-github.sts.yaml
@@ -7,7 +7,9 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
 
 permissions:
-  members: write # to add/remove GitHub members
+  administration: read # required to read the repository
+  contents: write # required per terraform docs (https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository)
+  members: read # to add/remove GitHub members
   metadata: read # to read metadata about the org
 
 repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
same we did for octo-sts org

xref: https://github.com/chainguard-dev/internal-dev/issues/11536